### PR TITLE
Add directory.build.props to add roslyn analyzers to all projects

### DIFF
--- a/Directory.Build.Props
+++ b/Directory.Build.Props
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Common-->
+
+<Project>
+  <ItemGroup>
+    <PackageReference Include="AsyncFixer">
+      <Version>1.6.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Meziantou.Analyzer">
+      <Version>1.0.738</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Analyzers">
+      <Version>4.2.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Formatting.Analyzers">
+      <Version>4.2.0</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SecurityCodeScan.VS2019">
+      <Version>5.6.7</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <Version>8.51.0.59060</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.7.101" />
+  </ItemGroup>
+</Project>

--- a/Library/Library.Shop/Library.Shop.Domain/Library.Shop.Domain.csproj
+++ b/Library/Library.Shop/Library.Shop.Domain/Library.Shop.Domain.csproj
@@ -5,4 +5,12 @@
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	  <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+	</PropertyGroup>
+
 </Project>

--- a/Library/Library.Shop/Library.Shop.Domain/Models/Cart.cs
+++ b/Library/Library.Shop/Library.Shop.Domain/Models/Cart.cs
@@ -18,7 +18,7 @@ namespace Library.Shop.Domain.Models
 
         public DateTime CreatedDate { get; private set; }
 
-        public virtual List<CartProduct> Items { get; private set; }
+        public virtual IList<CartProduct> Items { get; private set; }
         
         public void AddItem(int productId, int quantity)
         {
@@ -34,8 +34,7 @@ namespace Library.Shop.Domain.Models
         {
             var product = Items.FirstOrDefault(x => x.ProductId.Equals(productId));
 
-            if(product != null)
-                product.RemoveQuantity(quantity);
+            product?.RemoveQuantity(quantity);
 
             if (product.Quantity == 0)
                 Items.Remove(product);


### PR DESCRIPTION
In reality, we might not want all of these analyzers and even if we do we would need to look at the rules we want enabled and which ones we might suppress.

But it can highlight some interesting patterns
![image](https://user-images.githubusercontent.com/24911956/210645278-4cff56bc-346d-4c4f-a4e0-89471d514d70.png)

some are not so clear
![image](https://user-images.githubusercontent.com/24911956/210646143-f6bd8151-b314-4828-bd0a-4011ebb4bc98.png)

Also did a small fix and enabled warnings as errors on shop domain project.