### PR TITLE
Initial HealthCheck implementation

### DIFF
--- a/Library/Library.Shop/Library.Shop.Api/Library.Shop.Api.csproj
+++ b/Library/Library.Shop/Library.Shop.Api/Library.Shop.Api.csproj
@@ -7,6 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="6.0.4" />
+    <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="5.0.3" />
+    <PackageReference Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Core" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.2" />

--- a/Library/Library.Shop/Library.Shop.Api/Startup.cs
+++ b/Library/Library.Shop/Library.Shop.Api/Startup.cs
@@ -1,8 +1,11 @@
+using HealthChecks.UI.Client;
+
 using Library.Hub.Infrastructure.Setup;
 using Library.Hub.Logging.Setup;
 using Library.Shop.Database;
 using Library.Shop.Injection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -42,6 +45,10 @@ namespace Library.Shop.Api
 
             services.AddSwagger("Library.Shop");
 
+
+            services.AddHealthChecks()
+                .AddSqlServer(Configuration["ConnectionStrings:Context"]);
+
             services.AddControllers().AddNewtonsoftJson(options => {
                 options.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
             }).AddDaprForMvc();
@@ -77,6 +84,15 @@ namespace Library.Shop.Api
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");
             });
 
+            app.UseHealthChecks("/health", new HealthCheckOptions
+            {
+                Predicate = _ => true
+            })
+                .UseHealthChecks("/healthz", new HealthCheckOptions
+                {
+                    Predicate = _ => true,
+                    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                });
         }
     }
 }


### PR DESCRIPTION
Added a single [health check](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) for the SQL server in the Shop solution, it makes 2 new endpoint available
`/health` which gives an overall state of the service
![image](https://user-images.githubusercontent.com/24911956/210654954-481c6f59-f05d-4cf9-bcd1-86c08732807d.png)

and `/healthz` which returns a json response with the state of all health checks which can be consumed by the UI or other services in k8s I think
![image](https://user-images.githubusercontent.com/24911956/210654991-82f31d62-807b-4a98-946a-4c3ea22011ac.png)
